### PR TITLE
improve auth security and handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.angular
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@angular/router": "^17.1.0",
         "@angular/ssr": "^17.1.1",
         "express": "^4.18.2",
+        "md5": "^2.3.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.3"
@@ -31,6 +32,7 @@
         "@angular/compiler-cli": "^17.1.0",
         "@types/express": "^4.17.17",
         "@types/jasmine": "~5.1.0",
+        "@types/md5": "^2.3.5",
         "@types/node": "^18.18.0",
         "jasmine-core": "~5.1.0",
         "karma": "~6.4.0",
@@ -4520,6 +4522,12 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/md5": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.5.tgz",
+      "integrity": "sha512-/i42wjYNgE6wf0j2bcTX6kuowmdL/6PE4IVitMpm2eYKBUuYCprdcWVK+xEF0gcV6ufMCRhtxmReGfc6hIK7Jw==",
+      "dev": true
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -5550,6 +5558,14 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -6165,6 +6181,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/css-loader": {
@@ -7848,6 +7872,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "node_modules/is-core-module": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
@@ -8847,6 +8876,16 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/media-typer": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@angular/router": "^17.1.0",
     "@angular/ssr": "^17.1.1",
     "express": "^4.18.2",
+    "md5": "^2.3.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"
@@ -34,6 +35,7 @@
     "@angular/compiler-cli": "^17.1.0",
     "@types/express": "^4.17.17",
     "@types/jasmine": "~5.1.0",
+    "@types/md5": "^2.3.5",
     "@types/node": "^18.18.0",
     "jasmine-core": "~5.1.0",
     "karma": "~6.4.0",

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { AuthService } from '../service/auth.service';
+import md5 from 'md5';
 
 @Component({
   selector: 'app-login',
@@ -15,7 +16,7 @@ export class LoginComponent {
   constructor(private authService: AuthService, private router: Router) {}
 
   login() {
-    this.authService.login(this.username, this.password).subscribe(success => {
+    this.authService.login(this.username, md5(this.password)).subscribe(success => {
       if (success) {
         this.router.navigate(['/dashboard']); // Redirect to dashboard
       } else {

--- a/src/app/service/auth.service.ts
+++ b/src/app/service/auth.service.ts
@@ -11,14 +11,21 @@ import { Router } from '@angular/router';
 export class AuthService {
   private usersUrl = 'assets/users.json';
 
-  constructor(private http: HttpClient, private router: Router) {}
+  constructor(private http: HttpClient, private router: Router) {
+    // Check if currentUser is present in localStorage on service initialization
+    if (this.getCurrentUser() !== null) {
+      // Redirect to dashboard if currentUser is present
+      this.router.navigate(['/dashboard']);
+    }
+  }
 
   login(username: string, password: string): Observable<boolean> {
     return this.http.get<any[]>(this.usersUrl).pipe(
       map(users => {
         const user = users.find(u => u.username === username && u.password === password);
         if (user) {
-          localStorage.setItem('currentUser', JSON.stringify(user));
+          // Get only the name of the user and store in localStorage as currentUser
+          localStorage.setItem('currentUser', JSON.stringify({ name: user.name }));
           return true;
         } else {
           return false;

--- a/src/assets/users.json
+++ b/src/assets/users.json
@@ -1,4 +1,4 @@
 [
-  { "username": "user1", "password": "pass1", "name": "User One" },
-  { "username": "user2", "password": "pass2", "name": "User Two" }
+  { "username": "user1", "password": "a722c63db8ec8625af6cf71cb8c2d939", "name": "User One" },
+  { "username": "user2", "password": "c1572d05424d0ecb2a65ec6a82aeacbf", "name": "User Two" }
 ]


### PR DESCRIPTION
1. Created [.gitignore](https://git-scm.com/docs/gitignore) file
2. Included md5 package in the project
 npm install md5 --save
 npm install --save-dev @types/md5 
3. Convert the plain password in users.json file to md5 hash of the password
 Online [md5](https://www.md5hashgenerator.com/) tool
4. If the user session already exist in localStorage, then redirect the user to dashboard. See [AuthService](https://github.com/murshidrifay99/login/blob/improvements/src/app/service/auth.service.ts#L16).
5. Only store the name of the user instead of the entire user object. For security reasons, we shouldn't store password in localStorage. See [AuthService](https://github.com/murshidrifay99/login/blob/improvements/src/app/service/auth.service.ts#L28).